### PR TITLE
Add definition for Junk type

### DIFF
--- a/Types/Junk.kdl
+++ b/Types/Junk.kdl
@@ -1,0 +1,114 @@
+` Copyright (c) 2019-2020 Tom Hancocks
+`
+` Permission is hereby granted, free of charge, to any person obtaining a copy
+` of this software and associated documentation files (the "Software"), to deal
+` in the Software without restriction, including without limitation the rights
+` to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+` copies of the Software, and to permit persons to whom the Software is
+` furnished to do so, subject to the following conditions:
+`
+` The above copyright notice and this permission notice shall be included in all
+` copies or substantial portions of the Software.
+`
+` THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+` IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+` FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+` AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+` LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+` OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+` SOFTWARE.
+
+` Junk resources store info on specialized commodities that can be bought and
+` sold at a few locations.
+
+@type Junk : "jünk" {
+    template {
+        DWRD SoldAt1;
+        DWRD SoldAt2;
+        DWRD SoldAt3;
+        DWRD SoldAt4;
+        DWRD SoldAt5;
+        DWRD SoldAt6;
+        DWRD SoldAt7;
+        DWRD SoldAt8;
+        DWRD BoughtAt1;
+        DWRD BoughtAt2;
+        DWRD BoughtAt3;
+        DWRD BoughtAt4;
+        DWRD BoughtAt5;
+        DWRD BoughtAt6;
+        DWRD BoughtAt7;
+        DWRD BoughtAt8;
+        DWRD BasePrice;
+        HWRD Flags;
+        HWRD ScanMask;
+        C040 LCName;
+        C040 Abbrev;
+        C0FF BuyOn;
+        C0FF SellOn;
+    };
+
+    ` ID number of the stellar object where the commodity is sold. Set to 0 or
+    ` -1 if unused.
+    field("SoldAtStellar") repeatable<1, 8> {
+        SoldAt<$FieldNumber> as StellarObject& = #-1;
+    };
+
+    ` ID number of the stellar object where the commodity is purchased. Set to
+    ` 0 or -1 if unused.
+    field("BoughtAtStellar") repeatable<1, 8> {
+        BoughtAt<$FieldNumber> as StellarObject& = #-1;
+    };
+
+    ` The average price of the commodity (works much like the base prices for
+    ` "regular" commodities).
+    field("BasePrice") {
+        BasePrice;
+    };
+
+    ` Misc flag bits.
+    field("Flags") {
+        Flags as Bitmask = 0 [
+            ` Tribbles flag - When in your cargo bay, the commodity multiplies
+            ` like tribbles.
+            Tribbles = 0x0001,
+
+            ` Perishable - When in your cargo bay, the commodity gradually
+            ` decays away.
+            Perishable = 0x0002
+        ];
+    };
+
+    ` If this is an "illegal" cargo type, this is used in conjunction with the
+    ` ScanMask field in the gövt resource. If any of the 1 bits in a ship's
+    ` government's ScanMask field match any of the 1 bits in a jünk type's `
+    ` ScanMask field, that government will consider that junk cargo type
+    ` illegal. Set to zero if unused.
+    field("ScanMask") {
+        ScanMask as Bitmask = 0;
+    };
+
+    ` The lower-case string to display in the player-info dialog box, among
+    ` other places, e.g. "machine parts".
+    field("LowercaseName") {
+        LCName;
+    };
+
+    ` The short string that is displayed in the player's status bar when the
+    ` player is carrying jünk of this type, e.g. "Parts".
+    field("Abbreviation") {
+        Abbrev;
+    };
+
+    ` Control bit test expression. This jünk will only be available to be bought
+    ` when this expression evaluates true. Leave blank if unused.
+    field("BuyOnExpression") {
+        BuyOn;
+    };
+
+    ` Control bit test expression. This jünk will only be able to be sold when
+    ` this expression evaluates true. Leave blank if unused.
+    field("SellOnExpression") {
+        SellOn;
+    };
+};


### PR DESCRIPTION
Field information is from the EVN Bible, last revised on March 19th, 2004. All fields appear representable in existing KDL syntax.